### PR TITLE
Updated link to FHIR description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 API specification for approved test companies och care givers for communication with the Swedish Covid Certificate Service.
 
 * [The swagger file can be found here](https://diggsweden.github.io/Covidbevis-API/)
-* [The fhir resource description for the Observation payload can be found here](https://simplifier.net/guide/EUDCCSweden/ResourcesforTestcertificates)
+* [The fhir resource description for the Observation payload can be found here](https://simplifier.net/guide/EUDCCSweden/FHIRResourcesforrequestingTestcertificates)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) 
 


### PR DESCRIPTION
The observation payload FHIR description seems to have moved, as the link leads to a 404 error. This pull request updates the URL to what seems to be the intended page.